### PR TITLE
Successful implementation of render transition

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -27,8 +27,9 @@
         <canvas id="webgl-canvas"></canvas>
 
         <div class="loading-container">
-            <div class="loading-screen"></div>
+            <img class="loading-screen" />
         </div>
+
         <!-- everything in this container gets changed on page change -->
         <main data-barba="container" data-barba-namespace="about">
             <section class="about-section">

--- a/public/contact.html
+++ b/public/contact.html
@@ -28,8 +28,9 @@
         <canvas id="webgl-canvas"></canvas>
 
         <div class="loading-container">
-            <div class="loading-screen"></div>
+            <img class="loading-screen" />
         </div>
+
         <!-- everything in this container gets changed on page change -->
         <main data-barba="container" data-barba-namespace="contact">
             <section class="contact-section">

--- a/public/css/global-styles.css
+++ b/public/css/global-styles.css
@@ -31,6 +31,8 @@ h1 span {
 
 .loading-container {
     position: fixed;
+    margin: 0;
+    padding: 0;
     top: 0;
     left: 0;
     width: 100%;
@@ -41,17 +43,11 @@ h1 span {
 }
 
 .loading-screen {
+    display: none;
     position: relative;
-    padding-left: 0;
-    padding-right: 0;
-    padding-top: 0;
+    margin: 0;
+    padding: 0;
     width: 100%;
     height: 100%;
-    background-color: black;
-    left: 100vw;
-}
-
-.black {
-    background-color: black;
-    left: 100vw;
+    left: 0vw;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
         <canvas id="webgl-canvas"></canvas>
 
         <div class="loading-container">
-            <div class="loading-screen"></div>
+            <img class="loading-screen" />
         </div>
 
         <!-- everything in this container gets changed on page change -->

--- a/public/work.html
+++ b/public/work.html
@@ -28,7 +28,7 @@
         <canvas id="webgl-canvas"></canvas>
 
         <div class="loading-container">
-            <div class="loading-screen"></div>
+            <img class="loading-screen" / >
         </div>
 
         <!-- everything in this container gets changed on page change -->

--- a/src/transitions/FadeTransition.js
+++ b/src/transitions/FadeTransition.js
@@ -13,21 +13,21 @@ const charming = require('charming')
 export default class FadeTransition {
     constructor() {
         this.webglDuration = 2000
-        this.screenDuration = 0.3
+        this.screenDuration = 1.0
     }
 
     async screenIn() {
-        var screen = document.getElementsByClassName('loading-screen')[0]
-
-        var tl = TweenLite.to(screen, { left: 0, duration: this.screenDuration })
-        await tl
+        // var screen = document.getElementsByClassName('loading-screen')[0]
+        // var tl = TweenLite.to(screen, { left: 0, duration: this.screenDuration })
+        // await tl
     }
 
     async screenOut() {
         var screen = document.getElementsByClassName('loading-screen')[0]
-        var tl = TweenLite.to(screen, { left: '-100vw', duration: this.screenDuration })
+        var tl = TweenLite.to(screen, { opacity: 0, duration: this.screenDuration })
         await tl
-        screen.style.left = '100vw' // reset loading screen
+        screen.style.display = 'none' // reset loading screen
+        screen.style.opacity = 1 // reset loading screen
     }
 
     async leave(data) {
@@ -115,8 +115,15 @@ export default class FadeTransition {
             webgl.camera.inTransition = false
         }
 
-        // Screen in before material update
-        await this.screenIn()
+        function renderToImage() {
+            var imageDataURL = webgl.renderer.domElement.toDataURL('image/png')
+            var loadingScreen = document.getElementsByClassName('loading-screen')[0]
+            loadingScreen.src = imageDataURL
+            loadingScreen.style.display = 'block'
+        }
+
+        // Render old scene in new camera position
+        renderToImage()
 
         // Updates new scene (materials change here)
         await setNewScene()
@@ -124,6 +131,8 @@ export default class FadeTransition {
 
     async enter(data) {
         // Screen out after material update
+
+        // Fade out the render of the old scene
         this.screenOut()
     }
 }


### PR DESCRIPTION
Render old scene in new camera position to the loading screen img element. Barba then fades this element out. Performance concerns:
major frame drop when rendering the image to the html element but this is only for that instant.